### PR TITLE
fixed bug:

### DIFF
--- a/src/main/java/org/pkuse2020grp4/pkusporteventsbackend/service/ArticleService.java
+++ b/src/main/java/org/pkuse2020grp4/pkusporteventsbackend/service/ArticleService.java
@@ -10,8 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class ArticleService {
@@ -35,7 +34,14 @@ public class ArticleService {
         List<Article> articles;
         Sort sort = Sort.by(Sort.Direction.DESC, "articleId");
         articles = articleRepository.findArticlesByTagsIn(filterTags, sort);
-        return articles;
+        Set<Article> uniquedArticles=new HashSet<>(articles);
+/*
+        for (Article a:
+                uniquedArticles) {
+            System.out.println(a.getArticleId());
+        }
+*/
+        return new LinkedList<>(uniquedArticles);
     }
 
     public void addOrModifyArticle(Article article){


### PR DESCRIPTION
/api/article/getall returns multiple same articles when 2 or more tags contained by an article are required in one request.
It turns out that when jpa is doing query in join table, what it returns is not only not an intersection, but even not a set, cause it does not unique elements. For example, article 1 contains id 1,2, and our clients want to find articles containing both tag 1&2, then jpa just finds articles containing tag 1 and articles containing tag 2, then combine those 2 LIST, NOT SET.
One way to fix this problem is to change the query behavior from taking a union set to taking an intersection manually, where the simplest method is to query multiple times, in other words, query single tags one by one while reducing the article list.
But considering you seems to be very sensitive on performance issues, I haven't use this strategy, but only using java::Set to unique the results. In other words, we are still getting union sets from queries now.